### PR TITLE
Fix HMAC authentication to use correct form of secret

### DIFF
--- a/client/index.js
+++ b/client/index.js
@@ -60,7 +60,7 @@ function requestSigner(req) {
     if (SIGNER === 'httpSignature') {
         if (PRIVTOKEN) {
             httpSignature.signRequest(req, {
-                key: PRIVTOKEN,
+                key: Buffer.from(PRIVTOKEN, 'hex'),
                 keyId: 'recovery_token',
                 algorithm: 'hmac-sha256'
             });

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -74,7 +74,7 @@ function signatureAuth(req, res, next) {
         var reqTokens = piv.recovery_tokens.sort(function (a, b) {
             return a.created - b.created;
         });
-        key = reqTokens[reqTokens.length - 1]['token'];
+        key = Buffer.from(reqTokens[reqTokens.length - 1]['token'], 'hex');
     } else {
         key = piv.pubkeys['9e'];
     }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "backoff": "^2.5.0",
     "bunyan": "^1.8.12",
     "cmdln": "^6.0.0",
-    "http-signature": "^1.3.1",
+    "http-signature": "^1.3.2",
     "jsprim": "^2.0.0",
     "moray": "^3.7.0",
     "node-uuid": "1.4.8",


### PR DESCRIPTION
Hopefully this helps (and not hinders) -- (also let me know if I need to create a JIRA issue for this).. Based on my testing today, digging into the node-http-signature module, digging into the nodejs crypto module.. I figured out why the HMAC authentication was failing when replacing a PIV token after a key recovery -- node-http-signature was not allowing binary keys for HMAC (even though the crypto module has supported it since at least nodejs 0.10), so it was using the hex as a string (e.g. '00112233' not treated as byte values 0x00, 0x11, 0x22, 0x33, but as a string no different from "password"), preventing the verification.  node-http-signature has been updated (and published) to 1.3.2 to correct it, and this small change allows the HMAC authentication to succeed -- the only thing that might require tweaking is if with the other PR @kusor has out there for base64 bits might change the format