### PR TITLE
Store recovery token as base64 in moray, represent in memory as binary value

### DIFF
--- a/client/index.js
+++ b/client/index.js
@@ -60,7 +60,7 @@ function requestSigner(req) {
     if (SIGNER === 'httpSignature') {
         if (PRIVTOKEN) {
             httpSignature.signRequest(req, {
-                key: Buffer.from(PRIVTOKEN, 'hex'),
+                key: Buffer.from(PRIVTOKEN, 'base64'),
                 keyId: 'recovery_token',
                 algorithm: 'hmac-sha256'
             });

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -74,7 +74,7 @@ function signatureAuth(req, res, next) {
         var reqTokens = piv.recovery_tokens.sort(function (a, b) {
             return a.created - b.created;
         });
-        key = Buffer.from(reqTokens[reqTokens.length - 1]['token'], 'hex');
+        key = Buffer.from(reqTokens[reqTokens.length - 1]['token'], 'base64');
     } else {
         key = piv.pubkeys['9e'];
     }

--- a/lib/models/pivtoken.js
+++ b/lib/models/pivtoken.js
@@ -256,7 +256,7 @@ function createPIVToken(opts, callback) {
                 validate.params(CREATE_SCHEMA, null, opts.params, validCb);
             },
             function validateRecTokenParams(ctx, next) {
-                const token = crypto.randomBytes(40).toString('hex');
+                const token = crypto.randomBytes(40).toString('base64');
                 const tkUuid = model.uuid(token);
                 const tkParams = {
                     recovery_configuration: ctx.recoveryConfig.params.uuid,

--- a/lib/models/recovery-token.js
+++ b/lib/models/recovery-token.js
@@ -66,7 +66,7 @@ function RecoveryToken(params) {
         uuid: params.uuid,
         recovery_configuration: params.recovery_configuration,
         pivtoken: params.pivtoken,
-        token: params.token,
+        token: Buffer.from(params.token, 'base64'),
         created: params.created,
         staged: params.staged,
         activated: params.activated,
@@ -80,7 +80,7 @@ RecoveryToken.prototype.serialize = function serialize() {
     var self = this;
     var obj = {
         token: this.params.token ?
-            Buffer.from(this.params.token).toString('base64') : undefined,
+            this.params.token.toString('base64') : undefined,
         created: this.params.created,
         staged: this.params.staged,
         activated: this.params.activated,
@@ -115,7 +115,7 @@ function createRecoveryToken(opts, cb) {
 
     // If no token has been provided, just create a random one:
     if (!opts.params.token) {
-        opts.params.token = crypto.randomBytes(40).toString('hex');
+        opts.params.token = crypto.randomBytes(40);
     }
     // Ditto for the UUID. Let's just create a repeatable one:
     if (!opts.params.uuid) {


### PR DESCRIPTION
Testing with the latest bits combined still showed a couple problems. I think I've got it now -- with these changes, POST /pivtokens and POST /pivtokens/:guid/replace work (with one caveat on replacement). Unfortunately, I'm missing something in order to run all the tests, so I couldn't do those yet.