### PR TITLE
TRITON-2083 POST /pivtokens and POST /pivtokens/:guid/replace should have the same signature

### DIFF
--- a/client/index.js
+++ b/client/index.js
@@ -178,9 +178,7 @@ KBMAPI.prototype.replaceToken = function replaceToken(opts, cb) {
 
     var reqOpts = Object.assign(opts, {
         path: '/pivtokens/' + opts.guid + '/replace',
-        data: {
-            token: opts.token
-        },
+        data: opts.token,
         method: 'POST',
         authRequired: true,
         privtoken: opts.recovery_token

--- a/docs/README.md
+++ b/docs/README.md
@@ -617,7 +617,7 @@ Request-Id: 7e2562ba-731b-c91b-d7c6-90f2fd2d36a0
 Response-Time: 23
 ```
 
-### ReplacePivtoken (POST /pivtokens/:guid/replace)
+### ReplacePivtoken (POST /pivtokens/:replaced\_guid/replace)
 
 When a PIV token is no longer available (lost, damaged, accidentally reinitialized,
 etc.), a recovery must be performed.  This allows a new PIV token to replace the
@@ -630,7 +630,8 @@ that are sufficiently old to no longer be considered valid (even when accounting
 for propagation delays).
 
 The CN submits a ReplacePivtoken request to replace the unavailable PIV token
-with a new PIV token.  The `:guid` parameter is the guid of the unavailable PIV token.
+with a new PIV token.  The `:replaced_guid` parameter is the guid of the
+unavailable PIV token.
 The data included in the request is identical to that of a CreatePivtoken request.
 The major difference is that instead of using a PIV token's 9e key to sign the date
 field, the decrypted `recovery_token` value is used as the signing key.
@@ -644,12 +645,13 @@ a `404 Not Found` response.
 If the request fails to authenticate, a `401 Unauthorized` error
 is returned.
 
-If all the checks succeed, the information from the old PIV token (`:guid`) is
-moved to a history entry for that PIV token. Any subsequent requests to
-`/pivtokens/:guid` should either return a `404 Not found` reply. Note we do
-not try to return a `301 Moved Permanently` response with a new PIV token
-location because we could have a request to a PIV token which has already been
-replaced by another, which in turn has been replaced by another one ...
+If all the checks succeed, the information from the old PIV token
+(`:replaced_guid`) is moved to a history entry for that PIV token.
+Any subsequent requests to `/pivtokens/:replaced_guid` should either return a
+`404 Not found` reply. Note we do not try to return a `301 Moved Permanently`
+response with a new PIV token location because we could have a request to a PIV
+token which has already been replaced by another, which in turn has been
+replaced by another one ...
 
 The newly created PIV token will then be returned, together with the proper
 `Location` header (`/pivtokens/:new_guid`). In case of network/retry issues,

--- a/lib/endpoints/pivtokens.js
+++ b/lib/endpoints/pivtokens.js
@@ -33,8 +33,7 @@ const restify = require('restify');
  * this kind of authentication.
  */
 function preloadPivtoken(req, res, next) {
-    if (!req.params || (!req.params.guid &&
-        (!req.params.token || !req.params.token.guid))) {
+    if (!req.params || (!req.params.guid && !req.params.replaced_guid)) {
         next();
         return;
     }
@@ -43,7 +42,7 @@ function preloadPivtoken(req, res, next) {
         moray: req.app.moray,
         log: req.log,
         params: {
-            guid: req.params.guid || req.params.token.guid
+            guid: req.params.replaced_guid || req.params.guid
         }
     }, function getPivtokenCb(err, token) {
         if (err) {
@@ -281,8 +280,8 @@ function deletePivtoken(req, res, next) {
 
 
 /**
- * POST /pivtokens/:guid/replace: replace the given pivtoken :guid with a new
- * (provided) token.
+ * POST /pivtokens/:replaced_guid/replace: replace the given pivtoken :guid with
+ * a new (provided) token.
  *
  * This is a request authenticated using HMAC and original pivtoken's
  * recovery_token.
@@ -309,7 +308,7 @@ function replacePivtoken(req, res, next) {
         mod_pivtoken.create({
             moray: req.app.moray,
             log: req.log,
-            params: req.params.token
+            params: req.params
         }, function (createErr, token) {
             if (createErr) {
                 next(createErr);
@@ -642,7 +641,7 @@ function registerEndpoints(http, before) {
         name: 'getpivtokenpin'
     }, before, preloadPivtoken, mod_auth.signatureAuth, getPivtokenPin);
     http.post({
-        path: '/pivtokens/:guid/replace',
+        path: '/pivtokens/:replaced_guid/replace',
         name: 'replacepivtoken'
     }, before, preloadPivtoken, mod_auth.signatureAuth, replacePivtoken);
     http.get({


### PR DESCRIPTION
It's to say, get rid of `params.token = {}` in favor of just `params= {}`